### PR TITLE
Bump bundler, rake, and faraday_middleware

### DIFF
--- a/kounta.gemspec
+++ b/kounta.gemspec
@@ -17,15 +17,15 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.12'
+  spec.add_development_dependency 'bundler', '~> 2.1.4'
   spec.add_development_dependency 'pry', '0.9.12.2'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.56.0'
   spec.add_development_dependency 'simplecov', '0.7.1'
   spec.add_development_dependency 'webmock', '~> 3.0.0'
 
-  spec.add_dependency 'faraday_middleware', '~> 0.9'
+  spec.add_dependency 'faraday_middleware', '~> 1.2.0'
   spec.add_dependency 'hashie', '>= 2', '< 4'
   spec.add_dependency 'oauth2', '~> 1'
   spec.add_dependency 'oj', '>= 2', '< 4'

--- a/kounta.gemspec
+++ b/kounta.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '0.7.1'
   spec.add_development_dependency 'webmock', '~> 3.0.0'
 
-  spec.add_dependency 'faraday_middleware', '~> 1.2.0'
+  spec.add_dependency 'faraday_middleware', '>= 1', '< 2'
   spec.add_dependency 'hashie', '>= 2', '< 4'
   spec.add_dependency 'oauth2', '~> 1'
   spec.add_dependency 'oj', '>= 2', '< 4'


### PR DESCRIPTION
Bumping bundler and rake due to vulnerabilities https://github.com/TandaHQ/Kounta/security/dependabot/kounta.gemspec/bundler/open

Bumping faraday_middleware as it's needed for Ruby 3.0+ in Tanda