### PR TITLE
(fix) Drop Oj gem dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Switched from OJ gem to Ruby's native JSON library for better performance
 
 ### Fixed
 
 ### Removed
+- Removed OJ gem dependency
 
 
 ## [0.3.0] - 2018-11-28

--- a/kounta.gemspec
+++ b/kounta.gemspec
@@ -28,5 +28,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday_middleware', '~> 0.9'
   spec.add_dependency 'hashie', '>= 2', '< 4'
   spec.add_dependency 'oauth2', '~> 1'
-  spec.add_dependency 'oj', '>= 2', '< 4'
 end

--- a/lib/kounta/rest/client.rb
+++ b/lib/kounta/rest/client.rb
@@ -1,5 +1,4 @@
 require 'oauth2'
-require 'oj'
 require 'faraday_middleware'
 
 module Kounta

--- a/spec/kounta/company_spec.rb
+++ b/spec/kounta/company_spec.rb
@@ -1,12 +1,11 @@
 require 'helper'
-require 'oj'
 
 describe Kounta::Company do
   subject { Kounta::Company }
 
   it 'should be able to create a company from an existing hash' do
     path = File.expand_path('../fixtures/companies_me.json', __dir__)
-    subject.new(@client, Oj.load(File.read(path)))
+    subject.new(@client, JSON.parse(File.read(path)))
   end
 
   it 'should be able to create a company without a hash' do


### PR DESCRIPTION
## Description of changes

Byroot has taken over the native JSON gem the comes shipped with Ruby and looks to have made things faster. So dropping Oj for the base JSON gem.

Link to [blog here](https://byroot.github.io/ruby/json/2024/12/15/optimizing-ruby-json-part-1.html)

## Notes for code reviewers

Haven't done any benchmarking yet, just started removing from the work repo.

I've never forked and merged a PR so happy for feedback.

## Notes for testing